### PR TITLE
Resolve #29. Transfer ModalsContainer to App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -46,10 +46,12 @@
     <div class="content col-md-10 offset-md-1">
       <router-view/>
     </div>
+	<modals-container/>
   </div>
 </template>
 
 <script>
+import {container} from "jenesius-vue-modal"
 export default {
   name: "App",
   data() {
@@ -77,6 +79,9 @@ export default {
   },
   mounted() {
     this.query = new URLSearchParams(window.location.search).get('query');
+  },
+  components: {
+	  ModalsContainer: container
   }
 }
 

--- a/frontend/src/views/ArticleEditor.vue
+++ b/frontend/src/views/ArticleEditor.vue
@@ -58,14 +58,13 @@
         </div>
       </div>
     </form>
-    <article-summary-modal/>
   </div>
 </template>
 
 <script>
 import VMdEditor from '@kangc/v-md-editor';
 import ArticlesService from "@/api/ArticlesService";
-import {openModal, container} from "jenesius-vue-modal";
+import {openModal} from "jenesius-vue-modal";
 import ArticleSummaryModal from "@/components/ArticleSummaryModal";
 import TagService from "@/api/TagService";
 
@@ -73,7 +72,6 @@ export default {
   name: "ArticleEditor",
   components: {
     VMdEditor,
-    ArticleSummaryModal: container
   },
   data() {
     return {


### PR DESCRIPTION
[Issue link](https://github.com/TomSuworof/briene/issues/29)
Goal: Moving container that includes modals to *App.vue*